### PR TITLE
Fix extra inserts in diffs

### DIFF
--- a/sql/table_version_functions.sql
+++ b/sql/table_version_functions.sql
@@ -946,7 +946,7 @@ AS $FUNC$
                     %revision_table% AS T
                 WHERE (
                     (T._revision_created <= %1% AND T._revision_expired > %1% AND T._revision_expired <= %2%) OR
-                    (T._revision_created > %1%  AND T._revision_created <= %2%)
+                    (T._revision_created > %1%  AND T._revision_created <= %2% AND T._revision_expired > %2%)
                 )
                 ORDER BY
                     T.%key_col%, 


### PR DESCRIPTION
There's a pesky bug in the `ver_get_*_diff()` functions when rows get inserted _and_ deleted between the start and end revisions. These show up as inserts in the diff, but they shouldn't show up at all. This fix is a one-liner.
