### PR TITLE
Improve documentation of bde_TablesAffected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes for the LINZ BDE Uploader are documented in this file.
   are available for upload (#153)
 ### Fixed
 - Unpredictable exit code (use of uninitialized $exitcode variable)
+### Enhanced
+- Improve documentation of `bde_TablesAffected` (#173)
 
 ## [2.4.0] - 2017-12-11
 ### Changed

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1307,7 +1307,10 @@ Two useful functions that these may use are:
 
 =item INT bde_control.bde_TablesAffected( upload_id INT, tables name[], test TEXT )
 
-Tests tables that are affected by an upload. I<tables> is a list of tables to check.
+Tests tables that are affected by an upload. I<tables> is a list of
+table names to check. Names must NOT be qualified with schema name as
+the schema name is taken from the target schema of the given upload.
+
 <test> is a string specifying the test to apply and can include the following
 space separated items:
 

--- a/sql/02-bde_control_functions.sql.in
+++ b/sql/02-bde_control_functions.sql.in
@@ -2748,7 +2748,9 @@ ALTER FUNCTION bde_control.bde_ApplyPostUploadFunctions(INTEGER) OWNER TO bde_db
 --
 --  p_upload is the upload id of interest
 --
---  tables is an array or space separated string of tables to check.
+--  tables is an array of table names to check. Names must NOT be
+--  qualified with schema name as the schema name is taken from the
+--  target schema of the given upload (via p_upload).
 --
 --  test is a space separated string specifying the test to apply and
 --  can include the following items:


### PR DESCRIPTION
specify that schema name must NOT be provided as it is derived
from upload identifier.

Includes CHANGELOG entry

Closes #173