### PR TITLE
Do not duplicate logs on stdout on empty log_setting and -v switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes for the LINZ BDE Uploader are documented in this file.
   are given (#116)
 - Qualify calls to `bde_control` database functions for improved security
 - Downgrade INFO messages to NOTICE messages (#202)
+- Avoid duplicated stdout messages on -v and empty `log_settings` in
+  config file (#204)
 
 ## [2.5.0] - 2019-01-10
 ### Changed

--- a/bin/linz_bde_uploader.pl
+++ b/bin/linz_bde_uploader.pl
@@ -171,13 +171,16 @@ try
     };
 
     my $cfg = new LINZ::Config($options);
+    my $log_config;
 
     # turn off config logging if doing a dry run.
-    my $layout = Log::Log4perl::Layout::PatternLayout->new("%d %p> %F{1}:%L - %m%n");
+    my $log_layout_string = "%d %p> %F{1}:%L - %m%n";
+    my $layout = Log::Log4perl::Layout::PatternLayout->new($log_layout_string);
     if ($dry_run)
     {
         Log::Log4perl->easy_init( { level    => $INFO,
-                                    file     => "STDOUT" } );
+                                    file     => "STDOUT",
+                                    layout   => $log_layout_string} );
         $logger = get_logger("");
     }
     else
@@ -196,7 +199,8 @@ try
         else
         {
             Log::Log4perl->easy_init( { level    => $INFO,
-                                        file     => "STDOUT" } );
+                                        file     => "STDOUT",
+                                        layout   => $log_layout_string} );
             $logger = get_logger("");
         }
 
@@ -215,7 +219,7 @@ try
         }
     }
 
-    if($verbose)
+    if($verbose and $log_config and not $dry_run)
     {
         my $stdout_appender = Log::Log4perl::Appender->new(
             "Log::Log4perl::Appender::Screen",

--- a/t/linz_bde_uploader.t
+++ b/t/linz_bde_uploader.t
@@ -166,6 +166,7 @@ close($cfg_fh);
 
 # db_connection is now required now..
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, no db_connection' );
 is( $test->stdout, '', 'stdout, no db_connection' );
@@ -187,6 +188,7 @@ close($cfg_fh);
 
 # Attempts to connect to non-existing database
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, nonexistent db');
 is( $test->stdout, '', 'stdout, nonexistent db');
@@ -201,6 +203,7 @@ like( $log,
 
 # Dry run logs to stdout instead of logfile
 
+truncate $log_fh, 0;
 $test->run( args => "-full -dry-run -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, nonexistent db, dry-run');
 like( $test->stdout,
@@ -213,6 +216,7 @@ is( @logged, 0,
 
 # Dry run can also be specified with -d
 
+truncate $log_fh, 0;
 $test->run( args => "-full -d -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, nonexistent db, dry-run (-d)');
 like( $test->stdout,
@@ -233,6 +237,7 @@ close($cfg_fh);
 
 # -config-extension (or -x) adds an override configuration
 
+truncate $log_fh, 0;
 $test->run( args => "-full -d -config-path ${tmpdir}/cfg1 -config-extension ext" );
 is( $test->stderr, '', 'stderr, nonexist_override db, dry-run');
 like( $test->stdout,
@@ -245,6 +250,7 @@ is( @logged, 0,
 
 # -config-extension can also be passed as -x
 
+truncate $log_fh, 0;
 $test->run( args => "-full -d -config-path ${tmpdir}/cfg1 -x ext" );
 is( $test->stderr, '', 'stderr, nonexist_override db, dry-run (-x)');
 like( $test->stdout,
@@ -267,6 +273,7 @@ close($cfg_fh);
 
 # Run with ability to connect to database
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, empty db');
 is( $test->stdout, '', 'stdout, empty db');
@@ -298,6 +305,7 @@ END_OF_LOG_SETTINGS
 EOF
 close($cfg_fh);
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1 -x ext" );
 like( $test->stderr,
     qr/ERROR.*function bde_checkschema.*not exist.*Duration of job/ms,
@@ -316,6 +324,7 @@ close($cfg_fh);
 
 # Run again, should have less lines logged now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, empty db (terse)');
 is( $test->stdout, '', 'stdout, empty db (terse)');
@@ -425,6 +434,7 @@ is( @{$res}, 0, 'bde_control.upload is empty' );
 
 # Run with prepared database, it's missing bde_repository now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, missing bde_repository');
 is( $test->stdout, '', 'stdout, missing bde_repository');
@@ -447,6 +457,7 @@ close($cfg_fh);
 
 # Run with prepared database, it's missing level0 dir now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, missing level0 dir');
 is( $test->stdout, '', 'stdout, missing level0 dir');
@@ -474,6 +485,7 @@ mkdir $level0dir or die "Cannot create $level0dir";
 
 # Run with prepared database, it's missing available uploads now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, no uploads available');
 is( $test->stdout, '', 'stdout, no uploads available');
@@ -493,6 +505,7 @@ open($cfg_fh, ">>", "${tmpdir}/cfg1")
 print $cfg_fh "application_name TEST_APP_NAME\n";
 close($cfg_fh);
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, no uploads available, application_name');
 is( $test->stdout, '', 'stdout, no uploads available, application_name');
@@ -521,6 +534,7 @@ my $datadir = "t/data";
 
 # Missing table.conf requested test_file now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, missing test_file');
 is( $test->stdout, '', 'stdout, missing test_file');
@@ -546,6 +560,7 @@ copy($datadir.'/pab1.crs', $level0ds1.'/test_file.crs') or die "Copy failed: $!"
 
 # Missing test_table table in database
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, missing test_table');
 is( $test->stdout, '', 'stdout, missing test_table');
@@ -595,6 +610,7 @@ sub clean_stderr
 
 # This should supposedly be first successful upload
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 my $stderr = $test->stderr;
 $stderr =~ s/WARNING:.*dev.stdout//;
@@ -666,6 +682,7 @@ is( $res->[0]{'nnullupdate'}, '0', 'upload_stats[2].nnullupdate' );
 
 # Run full upload again - no updates to apply this time (by date)
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( $test->stderr, '', 'stderr, success upload test_file (2)');
 is( $test->stdout, '', 'stdout, success upload test_file (2)');
@@ -684,6 +701,7 @@ rename($level0ds1, $level0ds2)
 
 # Run full upload again, should find the new dataset now
 
+truncate $log_fh, 0;
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
 is( clean_stderr($test->stderr), '', 'stderr, success upload test_file (3)');
 is( $test->stdout, '', 'stdout, success upload test_file (3)');
@@ -721,6 +739,7 @@ rename($level0ds2, $level0ds3)
 # Run full upload again but only up to -before any dataset is
 # available
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -before 20170625" );
 is( $test->stderr, '', 'stderr, no uploads available (4)');
 is( $test->stdout, '', 'stdout, no uploads available (4)');
@@ -733,6 +752,7 @@ like( $log,
 
 # Now run full upload again but -before including available dataset
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -before 20170701" );
 is( clean_stderr($test->stderr), '', 'stderr, success upload test_file (4)');
 is( $test->stdout, '', 'stdout, success upload test_file (4)');
@@ -756,6 +776,7 @@ is( $res->[0]{'status'}, 'C', 'upload[4].status' );
 # Run full upload again, using -b for -before
 # No new data to upload
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -b 20170701" );
 is( $test->stderr, '', 'stderr, no dataset updates to apply(5)');
 is( $test->stdout, '', 'stdout, no dataset updates to apply (5)');
@@ -769,6 +790,7 @@ like( $log,
 # Run again but with -rebuild
 # No new data to upload
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -b 20170701 -rebuild" );
 is( clean_stderr($test->stderr), '', 'stderr, success upload test_file (5)');
 is( $test->stdout, '', 'stdout, success upload test_file (5)');
@@ -797,6 +819,7 @@ $res = $dbh->do(
 
 # -rebuild can be also passed as -r
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -b 20170701 -r" );
 is( clean_stderr($test->stderr), '', 'stderr, success upload test_file (6)');
 is( $test->stdout, '', 'stdout, success upload test_file (6)');
@@ -867,6 +890,7 @@ is( $res->[0]{'status'}, 'A', 'upload[7].status' );
 
 # Attempt to run a new job now
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -r" );
 is( $test->stderr, '', 'stderr, another job is already active (8)');
 is( $test->stdout, '', 'stdout, another job is already active (8)');
@@ -879,6 +903,7 @@ like( $log,
 
 # Override lock to run a new job now
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -r -override-locks" );
 is( clean_stderr($test->stderr), '', 'stderr, override-locks (8)');
 is( $test->stdout, '', 'stdout, override-locks (8)');
@@ -904,6 +929,7 @@ $res = $dbh->do("UPDATE bde_control.upload set status = 'A' where id = 8")
 
 # override-locks can be passed as -o too
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -r -o" );
 is( clean_stderr($test->stderr), '', 'stderr, override-locks (9)');
 is( $test->stdout, '', 'stdout, override-locks (9)');
@@ -931,6 +957,7 @@ print $cfg_fh "SELECT bde_control.bde_SetOption({{id}},'keep_temp_schema','yes')
 print $cfg_fh "EOT\n";
 close($cfg_fh);
 
+truncate $log_fh, 0;
 $test->run( args => "-f -c ${tmpdir}/cfg1 -r -o" );
 is( $? >> 8, 0, 'exit status, keep_temp_schema (10)');
 is( clean_stderr($test->stderr), '', 'stderr, keep_temp_schema (10)' );
@@ -966,6 +993,7 @@ is( $res->[0]{'status'}, 'C', 'upload[10].status' );
 my $level5dir = $repodir . '/level_5';
 mkdir $level5dir or die "Cannot create $level5dir";
 
+truncate $log_fh, 0;
 $test->run( args => "-incremental -c ${tmpdir}/cfg1" );
 is( clean_stderr($test->stderr), '', 'stderr, -incremental (no dataset)');
 is( $test->stdout, '', 'stdout, -incremental (no dataset)');
@@ -999,6 +1027,7 @@ system('sed', '-i',
 
 # Run incremental upload w/out known changetable in config
 
+truncate $log_fh, 0;
 $test->run( args => "-incremental -o -c ${tmpdir}/cfg1" );
 is( clean_stderr($test->stderr), '', 'stderr, -incremental (missing changetable)');
 is( $test->stdout, '', 'stdout, -incremental (missing changetable)');
@@ -1030,6 +1059,7 @@ close($cfg_fh);
 
 # Run incremental upload w/out changetable file
 
+truncate $log_fh, 0;
 $test->run( args => "-incremental -o -c ${tmpdir}/cfg1" );
 is( clean_stderr($test->stderr), '', 'stderr, -incremental (no changetable file)');
 is( $test->stdout, '', 'stdout, -incremental (no changetable file)');
@@ -1056,6 +1086,7 @@ copy($datadir.'/xaud.crs', $level5ds1.'/test_changeset.crs') or die "Copy failed
 
 # Run incremental upload
 
+truncate $log_fh, 0;
 $test->run( args => "-incremental -o -c ${tmpdir}/cfg1" );
 is( clean_stderr($test->stderr), '', 'stderr, -incremental (13)');
 is( $test->stdout, '', 'stdout, -incremental (13)');


### PR DESCRIPTION
Fixes #204

Also make output consistent with using the same log format string
for empty log_setting, -v and -dry-run switches

NOTE: I personally find Filename:Number too verbose, but this is what
I ended up pushing consistency to...