### PR TITLE
Do not set synchronous_commit off anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes for the LINZ BDE Uploader are documented in this file.
 - Map database NOTICE messages to log INFO instead of DEBUG (#218)
 - Avoid duplicated stdout messages on -v and empty `log_settings` in
   config file (#204)
+- Stop attempting to disable synchronous commit in default config
+  (#222)
 
 ## [2.5.2] - 2019-07-17
 ### Fixed

--- a/conf/linz_bde_uploader.conf
+++ b/conf/linz_bde_uploader.conf
@@ -51,7 +51,6 @@ SET client_encoding to UTF8;
 SET role bde_dba;
 SET search_path to {db_schema}, {bde_schema}, public;
 set DateStyle= ISO,MDY;
-SET LOCAL synchronous_commit TO OFF;
 EOT
 
 # SQL to be run each time on completion of an upload.  The text is split on


### PR DESCRIPTION
For a big single transaction it shouldn't help much, and using
the LOCAL keyword was making it a no-op anyway (beside raising
a warning).

See #219