### PR TITLE
Improve level5 check warnings/failres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes for the LINZ BDE Uploader are documented in this file.
 
 ## [2.6.0dev] - YYYY-MM-DD
+### Added
+- Level5 updates will now also be checked for change tolerance (#221)
+### Enhanced
 - `linz_bde_uploader` will fail if both -rebuild and -full-incremental
   are given (#116)
 - Qualify calls to `bde_control` database functions for improved security
 - Downgrade INFO messages to NOTICE messages (#202)
 - Map database NOTICE messages to log INFO instead of DEBUG (#218)
+- Provide default values for `level5_starttime_{warn,fail}_tolerance`
+  (#225)
+### Fixed
 - Avoid duplicated stdout messages on -v and empty `log_settings` in
   config file (#204)
 - Stop attempting to disable synchronous commit in default config

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1062,8 +1062,8 @@ sub CheckStartDate
     my ($self,$dataset,$file,$starttime,$checktime) = @_;
     return if $starttime eq $checktime;
 
-    my $warntol = $self->cfg->level5_starttime_warn_tolerance;
-    my $failtol = $self->cfg->level5_starttime_fail_tolerance;
+    my $warntol = $self->cfg->level5_starttime_warn_tolerance(0);
+    my $failtol = $self->cfg->level5_starttime_fail_tolerance(0);
     my $re = qw/^\d{4}\-\d\d\-\d\d\s+\d\d\:\d\d\:\d\d$/;
 
     if( $starttime !~ $re || $checktime !~ $re )

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -937,9 +937,9 @@ sub UploadTable
         $db->beginTable($tablename) ||
             die ("Cannot acquire upload lock for $tablename");
 
-        # If this is a level 0 update, then need the last update details
-        # in order to check that the start time of the current update
-        # matches the end time.
+        # If this is a level 5 update, we need the last update details
+        # in order to check that the start time of the current update is not
+        # too late when compared against the end time of the previous upload.
 
         my %lastdetails = ();
         if( ! $is_level0 )

--- a/sql/02-bde_control_functions.sql.in
+++ b/sql/02-bde_control_functions.sql.in
@@ -1765,6 +1765,9 @@ bde_control._bde_WorkingCopyTableOid(p_upload,bde_control._bde_ChangeTableName()
         INTO v_nins, v_ndel, v_nupd;
 
         DROP TABLE IF EXISTS _tmp_inc_actions;
+
+        RAISE NOTICE 'Checking table count';
+        PERFORM bde_control.bde_CheckTableCount(p_upload, p_table_name);
     ELSE
         RAISE NOTICE 'There are no changes to apply for %', p_table_name;
     END IF;

--- a/sql/02-bde_control_functions.sql.in
+++ b/sql/02-bde_control_functions.sql.in
@@ -1802,7 +1802,7 @@ EXCEPTION
     WHEN others THEN
         v_errmsg := 'Level 5 update of table ' || p_table_name ||
             ' from dataset ' || v_dataset || ' failed in ' || v_task ||
-            'Error:' || SQLERRM;
+            '. Error: ' || SQLERRM;
         IF v_sql <> '' THEN
             v_errmsg := v_errmsg || '. Last sql constructed: ' || v_sql;
         END IF;


### PR DESCRIPTION
- Run table changes analysis on level 5 updates (#221)
 - Provide default values for starttime warn/fail (#225)