### PR TITLE
Still run DDL queries when bde_control schema exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes for the LINZ BDE Uploader are documented in this file.
 - `linz-bde-uploader-schema-publish` script to publish schema tables (#237)
 ### Enhanced
 - Do not DROP TABLE on -full upload (#148)
+- Lost tables and permissions now recovered upon schema loading (#240)
 
 ## [2.6.0] - 2019-09-09
 ### Added


### PR DESCRIPTION
Sets permissions at once at end of schema creation
Re-creates lost tables and indexes

Will also restore lost/changed permissions on schema elements