### PR TITLE
Fix config and dox pretending to use `bde_dba` instead of `bde_admin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,16 +108,16 @@ by setting a `BDEUPLOADER_SQLDIR` environment variable.
 #### User setup
 
 Lastly the `linz_bde_uploader` software should be run under a UNIX account that
-also has PostgreSQL `bde_dba` database access. It is best to first create a
+also has PostgreSQL `bde_admin` database access. It is best to first create a
 system user account as well so ident authentication can be used.
 
 ```shell
 adduser --system --gecos "BDE Maintainer" bde
 ```
 
-The bde PostgreSQL user account needs to have `bde_dba` rights, but does not
-need to have superuser rights by default. An example SQL create user script
-could look like:
+The bde PostgreSQL user account needs to have `bde_admin` rights, but does
+not need to have superuser rights by default.
+An example SQL create user script could look like:
 
 ```sql
 DO $$
@@ -126,7 +126,7 @@ BEGIN
         CREATE ROLE bde LOGIN
               NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;
         ALTER ROLE bde SET search_path=bde, bde_control, lds, public;
-        GRANT bde_dba TO bde;
+        GRANT bde_admin TO bde;
     END IF;
 END
 $$;

--- a/conf/linz_bde_uploader.conf
+++ b/conf/linz_bde_uploader.conf
@@ -48,7 +48,6 @@ bde_schema bde
 # job id.
 db_connect_sql <<EOT
 SET client_encoding to UTF8;
-SET role bde_dba;
 SET search_path to {db_schema}, {bde_schema}, public;
 set DateStyle= ISO,MDY;
 EOT


### PR DESCRIPTION
We really only need `bde_admin`, and actually we switch to that
account from within code, as soon as possible.