### PR TITLE
Grant bde_admin privileges at runtime rather than schema-creation time

### DIFF
--- a/lib/LINZ/BdeDatabase.pm
+++ b/lib/LINZ/BdeDatabase.pm
@@ -331,6 +331,8 @@ sub new
 
 
     # Immediately switch to the role meant to run uploads (`bde_admin`)
+    # FIXME: Workaround for https://github.com/linz/linz-bde-schema/issues/173
+    $dbh->do("DO \$\$ BEGIN EXECUTE format('GRANT CREATE ON DATABASE %I TO bde_admin', current_database()); END; \$\$ LANGUAGE 'plpgsql'");
     $dbh->do("SET SESSION AUTHORIZATION bde_admin");
 
     if ( $self->{_pg_server_version} >= 90000 )

--- a/sql/01-bde_control_tables.sql
+++ b/sql/01-bde_control_tables.sql
@@ -222,13 +222,6 @@ GRANT USAGE
     ON ALL SEQUENCES IN SCHEMA bde_control
     TO bde_admin;
 
--- FIXME: Workaround for https://github.com/linz/linz-bde-schema/issues/173
-DO $$
-BEGIN
-    EXECUTE format('GRANT CREATE ON DATABASE %I TO bde_admin',
-            current_database());
-END; $$ LANGUAGE 'plpgsql';
-
 GRANT SELECT
     ON ALL TABLES IN SCHEMA bde_control
     TO bde_user;


### PR DESCRIPTION
Helps when a database is not prepared via schema-loader but rather
created by restoring a dump of a prepared database.