### PR TITLE
[debian] Fix dependency on tableversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
             postgresql-${{ matrix.pg }}-pgtap \
             postgresql-${{ matrix.pg }}-postgis-${{ matrix.pgis }} \
             postgresql-${{ matrix.pg }}-postgis-${{ matrix.pgis }}-scripts \
+            postgresql-${{ matrix.pg }}-dbpatch \
+            postgresql-${{ matrix.pg }}-tableversion \
             dbpatch \
             tableversion \
             libtest-cmd-perl \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,15 @@ jobs:
             cpanminus \
             debhelper \
             fakeroot \
+            postgresql-${{ matrix.pg }} \
             postgresql-client-${{ matrix.pg }} \
             postgresql-contrib-${{ matrix.pg }} \
-            postgresql-${{ matrix.pg }} \
-            postgresql-${{ matrix.pg }}-dbpatch \
+            postgresql-server-dev-${{ matrix.pg }} \
             postgresql-${{ matrix.pg }}-pgtap \
             postgresql-${{ matrix.pg }}-postgis-${{ matrix.pgis }} \
             postgresql-${{ matrix.pg }}-postgis-${{ matrix.pgis }}-scripts \
-            postgresql-${{ matrix.pg }}-tableversion \
-            postgresql-server-dev-${{ matrix.pg }} \
+            dbpatch \
+            tableversion \
             libtest-cmd-perl \
             libtest-exception-perl \
             libtap-parser-sourcehandler-pgtap-perl \

--- a/debian/control
+++ b/debian/control
@@ -31,10 +31,8 @@ Depends: ${misc:Depends}, ${perl:Depends},
  cifs-utils,
  perl-doc,
  postgresql-client-11 | postgresql-client-10 | postgresql-client-9.6 | postgresql-client-9.5 | postgresql-client-9.4 | postgresql-client-9.3,
- tableversion
+ tableversion, postgresql-11-tableversion | postgresql-10-tableversion | postgresql-9.6-tableversion | postgresql-9.5-tableversion | postgresql-9.4-tableversion | postgresql-9.3-tableversion
 Recommends:
- postgresql-11-tableversion | postgresql-10-tableversion | postgresql-9.6-tableversion | postgresql-9.5-tableversion | postgresql-9.4-tableversion | postgresql-9.3-tableversion
-Suggests:
  postgresql-11 | postgresql-10 | postgresql-9.6 | postgresql-9.5 | postgresql-9.4 | postgresql-9.3
 Description: Programme for loading LINZ BDE files into a PostgreSQL
  database. linz_bde_uploader has the ability to load full and incremental

--- a/debian/control
+++ b/debian/control
@@ -31,9 +31,8 @@ Depends: ${misc:Depends}, ${perl:Depends},
  cifs-utils,
  perl-doc,
  postgresql-client-11 | postgresql-client-10 | postgresql-client-9.6 | postgresql-client-9.5 | postgresql-client-9.4 | postgresql-client-9.3,
- tableversion | postgresql-11-tableversion | postgresql-10-tableversion | postgresql-9.6-tableversion | postgresql-9.5-tableversion | postgresql-9.4-tableversion | postgresql-9.3-tableversion
-Recommends:
- postgresql-11 | postgresql-10 | postgresql-9.6 | postgresql-9.5 | postgresql-9.4 | postgresql-9.3
+ tableversion,
+ dbpatch
 Description: Programme for loading LINZ BDE files into a PostgreSQL
  database. linz_bde_uploader has the ability to load full and incremental
  table Landonline BDE loads, as well as manage versioning information.

--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Depends: ${misc:Depends}, ${perl:Depends},
  cifs-utils,
  perl-doc,
  postgresql-client-11 | postgresql-client-10 | postgresql-client-9.6 | postgresql-client-9.5 | postgresql-client-9.4 | postgresql-client-9.3,
- tableversion, postgresql-11-tableversion | postgresql-10-tableversion | postgresql-9.6-tableversion | postgresql-9.5-tableversion | postgresql-9.4-tableversion | postgresql-9.3-tableversion
+ tableversion | postgresql-11-tableversion | postgresql-10-tableversion | postgresql-9.6-tableversion | postgresql-9.5-tableversion | postgresql-9.4-tableversion | postgresql-9.3-tableversion
 Recommends:
  postgresql-11 | postgresql-10 | postgresql-9.6 | postgresql-9.5 | postgresql-9.4 | postgresql-9.3
 Description: Programme for loading LINZ BDE files into a PostgreSQL


### PR DESCRIPTION
If Recommended `postgresql-X.Y-tableversion` package would be installed it would try to override files (like loader script) in `tableversion` which would fail. So has to be alternative `tableversion` or `postgresql-X.Y-tableversion`. Can't be both