### PR TITLE
Restore transactionality during loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes for the LINZ BDE Uploader are documented in this file.
 ## [2.9.0-dev] - 2020-MM-DD
 ### Enhanced
 - Only ALTER table on upgrade if really needed (#256)
+### Fixed
+- UTF8 characters encoding (#210)
 
 ## [2.8.0] - 2020-02-11
 ### Changed

--- a/bin/linz-bde-uploader-schema-load.pl
+++ b/bin/linz-bde-uploader-schema-load.pl
@@ -142,7 +142,8 @@ if ( $TABLEVERSION_SUPPORTS_STDOUT ) {
     open(my $loader, "table_version-loader ${EXTOPT} - |")
         or die "Could not run table_version -\n";
     while (<$loader>) {
-        # NOTE: begin/commit will be filtered later
+        next if /^BEGIN;/;
+        next if /^COMMIT;/;
         print $sql $_;
     }
     close($loader);
@@ -153,7 +154,8 @@ if ( $DBPATCH_SUPPORTS_STDOUT ) {
     open(my $loader, "dbpatch-loader ${EXTOPT} - _patches |")
         or die "Could not run dbpatch_loader -\n";
     while (<$loader>) {
-        # NOTE: begin/commit will be filtered later
+        next if /^BEGIN;/;
+        next if /^COMMIT;/;
         print $sql $_;
     }
     close($loader);


### PR DESCRIPTION
Presence of spurious BEGIN/COMMIT lines from tableversion and dbpatch
loaders resulted in multiple transactions occurring during load of
the bde-uploader schema.

Closes #267

It would be useful to secure a test for this!